### PR TITLE
fix: remove unit suffixes from lychee duration args

### DIFF
--- a/.github/workflows/links-watcher.yml
+++ b/.github/workflows/links-watcher.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           args: >-
             --verbose --no-progress --max-concurrency 2 --max-retries 4
-            --retry-wait-time 2s --timeout 30s --host-concurrency 1
-            --host-request-interval 1s --cache --max-cache-age 7d
+            --retry-wait-time 2 --timeout 30 --host-concurrency 1
+            --host-request-interval 1 --cache --max-cache-age 7d
             --exclude-link-local --exclude-loopback './**/*.md'
             --exclude portal.azure.com --exclude developers.sap.com
             --exclude shell.azure.com


### PR DESCRIPTION
## Summary

lychee v0.23.0 (used by \lycheeverse/lychee-action@v2.8.0\) dropped support for the \s\ unit suffix on duration arguments. Passing \2s\, \30s\, \1s\ now produces:

\\\
error: invalid value '2s' for '--retry-wait-time <RETRY_WAIT_TIME>': invalid digit found in string
\\\

This caused the link-checker job to always exit with code 2 (argument parsing error) before checking any links, which in turn created the automated issue #51.

## Change

Strip the \s\ suffix from \--retry-wait-time\, \--timeout\, and \--host-request-interval\ — lychee now expects plain integers (seconds).

Fixes #51